### PR TITLE
fix(haproxy): Configured ACME to restart haproxy

### DIFF
--- a/nixos/modules/haproxy/default.nix
+++ b/nixos/modules/haproxy/default.nix
@@ -85,7 +85,13 @@ in {
 
       security.acme = lib.mkIf cfg.ssl.enable {
         acceptTerms = true;
-        defaults.email = "justintrubek@protonmail.com";
+        defaults = {
+          email = "justintrubek@protonmail.com";
+
+          reloadServices = [
+            "haproxy.service"
+          ];
+        };
         certs = {
           "rubek.cloud" = {
             domain = "*.rubek.cloud";


### PR DESCRIPTION
This hasn't been tested, but the intent is that haproxy will be restarted when a certificate is renewed. This should keep the cert up to date without manual intervention. Previously haproxy would keep the same cert loaded as it only loads once during startup.