### PR TITLE
switch to opentofu

### DIFF
--- a/containers/default.nix
+++ b/containers/default.nix
@@ -55,8 +55,6 @@
       };
 
       "image/conduit" = inputs'.conduit.packages."image/conduit";
-
-      "image/postgres" = inputs'.lockpad.packages."postgres/docker";
     };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -5392,11 +5392,11 @@
         "terranix": "terranix"
       },
       "locked": {
-        "lastModified": 1696555498,
-        "narHash": "sha256-PD1bJRPtFq0Hc9ig22dcmZgy17dm6l9w+EXTzHCJ8+s=",
+        "lastModified": 1701753013,
+        "narHash": "sha256-br+6QQ88vivmRPGVCWlizO9x44NLcYcbv3nGNn3dbmw=",
         "owner": "justinrubek",
         "repo": "thoenix",
-        "rev": "22ab04e80d22d28325f0b08bd2b408cbe11ff415",
+        "rev": "33e8c068321d299576e485d80dd5619dbb904788",
         "type": "github"
       },
       "original": {

--- a/terraform/configurations/apps/.terraform.lock.hcl
+++ b/terraform/configurations/apps/.terraform.lock.hcl
@@ -1,22 +1,20 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/nomad" {
+provider "registry.opentofu.org/hashicorp/nomad" {
   version     = "1.4.19"
   constraints = "1.4.19"
   hashes = [
-    "h1:EdBny2gaLr/IE+l+6csyCKeIGFMYZ/4tHKpcbS7ArgE=",
-    "zh:2f3ceeb3318a6304026035b0ac9ee3e52df04913bb9ee78827e58c5398b41254",
-    "zh:3fbe76c7d957d20dfe3c8c0528b33084651f22a95be9e0452b658e0922916e2a",
-    "zh:595671a05828cfe6c42ef73aac894ac39f81a52cc662a76f37eb74ebe04ddf75",
-    "zh:5d76e8788d2af3e60daf8076babf763ec887480bbb9734baccccd8fcddf4f03e",
-    "zh:676985afeaca6e67b22d60d43fd0ed7055763029ffebc3026089fe2fd3b4a288",
-    "zh:69152ce6164ac999a640cff962ece45208270e1ac37c10dac484eeea5cf47275",
-    "zh:6da0b15c05b81f947ec8e139bd81eeeb05c0d36eb5a967b985d0625c60998b40",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:822c0a3bbada5e38099a379db8b2e339526843699627c3be3664cc3b3752bab7",
-    "zh:af23af2f98a84695b25c8eba7028a81ad4aad63c44aefb79e01bbe2dc82e7f78",
-    "zh:e36cac9960b7506d92925b667254322520966b9c3feb3ca6102e57a1fb9b1761",
-    "zh:ffd1e096c1cc35de879c740a91918e9f06b627818a3cb4b1d87b829b54a6985f",
+    "h1:iYKD+sgStR8XalDN5lYyiaGow3uQ8NGeFDY9PG9ELi4=",
+    "zh:013443aae02a6686c8c01d839e3c6ed9dd519d2f0099f554e747f95266fa8b25",
+    "zh:151157529947f7306c67571586e681bb2b86059f44623beebe1b4327ca1d90f9",
+    "zh:3f29947827e18365ab24b8ac70e85731f5cd542c13e24ea808005297b2f13a4f",
+    "zh:715e417cdcaeaaa7aa1dbf93a4f22f5a9f5216397a90435b7ea831a010be8345",
+    "zh:7e0fe562f0a6f33ccdbc6299bac8a01b4a0ec467004309a672b5978369645286",
+    "zh:ab251887d8036353465e46196a88ede116b8e86469645283a899c8dde89e2235",
+    "zh:c9c32896b8b00322b4b39fa2f36954df7e0a2f30c1a89ceff368a096d5bc8352",
+    "zh:d3693d3a73de80515adeaf589c876ad9c836522ee7f014d45fbd75c63b671ad0",
+    "zh:d7e0af333c489213d2af611be94db350aa295663e7a737a8789f366faa3aaaf9",
+    "zh:dd658c5bb1c24f47db930f2adcf001680b2192dea65931b27529f2b31a554290",
   ]
 }

--- a/terraform/configurations/apps/backend.tf
+++ b/terraform/configurations/apps/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   cloud {
     organization = "justinrubek"
+    hostname = "app.terraform.io"
 
     workspaces {
       name = "apps"
@@ -9,9 +10,10 @@ terraform {
 
   required_providers {
     nomad = {
+      source = "hashicorp/nomad"
       version = "1.4.19"
     }
   }
 
-  required_version = ">= 1.0"
+  required_version = "1.6.0"
 }

--- a/terraform/configurations/consul/.terraform.lock.hcl
+++ b/terraform/configurations/consul/.terraform.lock.hcl
@@ -1,7 +1,7 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/carlpett/sops" {
+provider "registry.opentofu.org/carlpett/sops" {
   version     = "0.7.1"
   constraints = "0.7.1"
   hashes = [
@@ -16,41 +16,38 @@ provider "registry.terraform.io/carlpett/sops" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/consul" {
-  version = "2.17.0"
+provider "registry.opentofu.org/hashicorp/consul" {
+  version     = "2.20.0"
+  constraints = "2.20.0"
   hashes = [
-    "h1:k+8ptRn/iiCnE7mC0LVA8FvnukzKnlD3KAcquPFbtN8=",
-    "zh:1cca5e144b4696900d2410e26499a00c9666e5777b657e9844a4b6d198164a09",
-    "zh:4fe59329ae4a4fc13751cde4a1044427ca591ecefbaa8dde2ce828f660fbddb1",
-    "zh:55c42cec7dd10ee1f03eca03d5b8e3bcba7bf281bcd250ac220458aba735ba1f",
-    "zh:625a0481d0b2599d0e6ac609d9efc151f1c9cad53091e2ee3bfcedc34ccacb34",
-    "zh:7e9a08b19491f26aa685311a9211bacd7b7027d9cf6eaee16949435221a5f688",
-    "zh:9d92816f609367204c4df20c29c57ee631f5a65cf6bb782d9d9b3f945ba21353",
-    "zh:a332ef65a6ba829dc335ade1a3e69ae14e162dc6ca1a991d9d6ad4e596f4c2d7",
-    "zh:ce7ffac8d852342e9fe25053383613934c8b81d8c2ba2c9d10626b71e329fed7",
-    "zh:d384a1ef35c766362e8ae3131d00c05e1c0904d8b4b1d964548b91e1025f324b",
-    "zh:d85067f345b663e8e59fb02705918d3618ce56887a472665bec7f1aeddbc9ea4",
-    "zh:ddff8512e8181efae6d0d259abcd457d9a394a4a6f99d6bb0b180cabee373097",
-    "zh:f3d3efac504c9484a025beb919d22b290aa6dbff256f6e86c1f8ce7817e077e5",
+    "h1:sjMCNMTWV3BRnMAuzjkXEkOTKApxZytYf+nb67gal84=",
+    "zh:1d5d466334b75ef4b6c77da630c8a6eb6373875b16b059c9a55b73aa1e98cb34",
+    "zh:30df9e0745eae9fd467d691c0dedafb47a70f883c0221c089ed12532eeb9a6af",
+    "zh:5db4c2a66c84caf95a8704e6d16d4b64bbdd939d040bc6a373b92da36349f5df",
+    "zh:6ac1a34512ed6a64fc24d5b04bc25901454c1e0491a090621dd762d6baa64709",
+    "zh:6de32ce63ea17db1736c52769088d3622e66d105aa891a37ba5efd61dce78011",
+    "zh:a847caf28e422aa950d4ed8c9f8642ae6847d6f2258175ca76757bbd6b845355",
+    "zh:b9c73fadd38aaef535a831b73e98b77836e0dbb2c99e6da60125d94d394de372",
+    "zh:da421bcfd4cc63b0e5f9b89138d8c19de2c4177ab2862037549a650500646519",
+    "zh:e26024e6dce3d370dbf3cf1a7f6ac602f47331d8a96e86a995347e7bd2798b3d",
+    "zh:e8f84137e83ff282927af5c8eb167e69edd987ca4851ddd063c5091d951e2bad",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/vault" {
+provider "registry.opentofu.org/hashicorp/vault" {
   version     = "3.11.0"
   constraints = "3.11.0"
   hashes = [
-    "h1:AUVEra6fAOiAUWa0FOU+ehx4K2htbsfgLDrMh1H6mQs=",
-    "zh:18cb684852f1b40b2a329ba07ece3363430d69bffdcafea48ed29f954481e39e",
-    "zh:1b96968a8de6849a237cc945cbe247ccd6ec98b4023548b1c0af5d6c6affe4ef",
-    "zh:3e0a0741ba12aa0cf1a2b8b80928450bb329343f4b41f35b0eddbeb52aa6284b",
-    "zh:4a8f0ee5ac4e8a0705d9f38b3d549223fe1142486d71f0b6f24f64ae0d7dd5ca",
-    "zh:4cc6705dcd111e6ad47ab4cfd2d8a99b2b241967abd50add6ac8c27025f4128b",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8e106e840a963b9ae32dc24b50fa1ceecb09753e6db10ab134009d59d170686b",
-    "zh:8f9c4ccf4da8555b11375d2a09a022d7a8f5ecf701f0bb89a4f07ad0b720bb98",
-    "zh:a6fda115017b42f71f4b7917ae4860354920f0653cb8906ce627129dbabb252b",
-    "zh:c01666362b293b6af8cd556b2c5ffe9014ae8640ec3621c1cfa772fa1a6b335d",
-    "zh:e9be58b1211da0219a5bf6bfd81b8bf474256519426df10672e6dfce3086af60",
-    "zh:fd2272083e90b38c28cd18b1b9d3ae14b6a0ebf08985468d010d2bee8df816e0",
+    "h1:82HeeI++FQCwIxWkt344S2K9Epcdj74XMPQehekNwXI=",
+    "zh:13c84ce1ffeaa98f6ec00d39b570b3b02b46bb7f550d9d77adfbbc6a5f236bb3",
+    "zh:54e93ff32a599875ad9441c5f1ca0c1f11329474a483895a033f30771c692e47",
+    "zh:54fab02b23c021c0a7171e33ba1ac6be0ea3986ce4e97de0f21413506109a421",
+    "zh:8a016e456014b88e217f93edd8a3ec0663d3669781d7709304e94536f7820fb3",
+    "zh:9ccfbb19b10ad654cd45c2f54a8ea6abd79f570f6f474b1522c30473a52055fe",
+    "zh:a9492d604633b3c92033cfc2eebe9f51300f9dc7ea38459d6394514242fc5809",
+    "zh:b878f04e59b0ab061015a64d76a96bbc7a26b0d4b1065ef81df913a6fffcfd77",
+    "zh:c456639e7024d3120d9cb0b2fcb0c875443e31212ab8f05e52c4d43591496631",
+    "zh:e338af6474db7feb142287f93460d43d5c892a150c91f26354dff1b0294438a4",
+    "zh:ebdc4cc6c655ba9c1c3b3fbf3d7464d84a31e74fa5b484676fbdfd8870f29128",
   ]
 }

--- a/terraform/configurations/consul/backend.tf
+++ b/terraform/configurations/consul/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   cloud {
     organization = "justinrubek"
+    hostname = "app.terraform.io"
 
     workspaces {
       name = "consul"
@@ -9,9 +10,12 @@ terraform {
 
   required_providers {
     vault = {
+      source = "hashicorp/vault"
       version = "3.11.0"
     }
     consul = {
+      source = "hashicorp/consul"
+      version = "2.20.0"
     }
     sops = {
       source = "carlpett/sops"
@@ -19,5 +23,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.0"
+  required_version = "1.6.0"
 }

--- a/terraform/configurations/dns/.terraform.lock.hcl
+++ b/terraform/configurations/dns/.terraform.lock.hcl
@@ -1,7 +1,7 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/cullenmcdermott/porkbun" {
+provider "registry.opentofu.org/cullenmcdermott/porkbun" {
   version     = "0.1.2"
   constraints = "0.1.2"
   hashes = [
@@ -24,22 +24,20 @@ provider "registry.terraform.io/cullenmcdermott/porkbun" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/vault" {
+provider "registry.opentofu.org/hashicorp/vault" {
   version     = "3.11.0"
   constraints = "3.11.0"
   hashes = [
-    "h1:AUVEra6fAOiAUWa0FOU+ehx4K2htbsfgLDrMh1H6mQs=",
-    "zh:18cb684852f1b40b2a329ba07ece3363430d69bffdcafea48ed29f954481e39e",
-    "zh:1b96968a8de6849a237cc945cbe247ccd6ec98b4023548b1c0af5d6c6affe4ef",
-    "zh:3e0a0741ba12aa0cf1a2b8b80928450bb329343f4b41f35b0eddbeb52aa6284b",
-    "zh:4a8f0ee5ac4e8a0705d9f38b3d549223fe1142486d71f0b6f24f64ae0d7dd5ca",
-    "zh:4cc6705dcd111e6ad47ab4cfd2d8a99b2b241967abd50add6ac8c27025f4128b",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8e106e840a963b9ae32dc24b50fa1ceecb09753e6db10ab134009d59d170686b",
-    "zh:8f9c4ccf4da8555b11375d2a09a022d7a8f5ecf701f0bb89a4f07ad0b720bb98",
-    "zh:a6fda115017b42f71f4b7917ae4860354920f0653cb8906ce627129dbabb252b",
-    "zh:c01666362b293b6af8cd556b2c5ffe9014ae8640ec3621c1cfa772fa1a6b335d",
-    "zh:e9be58b1211da0219a5bf6bfd81b8bf474256519426df10672e6dfce3086af60",
-    "zh:fd2272083e90b38c28cd18b1b9d3ae14b6a0ebf08985468d010d2bee8df816e0",
+    "h1:82HeeI++FQCwIxWkt344S2K9Epcdj74XMPQehekNwXI=",
+    "zh:13c84ce1ffeaa98f6ec00d39b570b3b02b46bb7f550d9d77adfbbc6a5f236bb3",
+    "zh:54e93ff32a599875ad9441c5f1ca0c1f11329474a483895a033f30771c692e47",
+    "zh:54fab02b23c021c0a7171e33ba1ac6be0ea3986ce4e97de0f21413506109a421",
+    "zh:8a016e456014b88e217f93edd8a3ec0663d3669781d7709304e94536f7820fb3",
+    "zh:9ccfbb19b10ad654cd45c2f54a8ea6abd79f570f6f474b1522c30473a52055fe",
+    "zh:a9492d604633b3c92033cfc2eebe9f51300f9dc7ea38459d6394514242fc5809",
+    "zh:b878f04e59b0ab061015a64d76a96bbc7a26b0d4b1065ef81df913a6fffcfd77",
+    "zh:c456639e7024d3120d9cb0b2fcb0c875443e31212ab8f05e52c4d43591496631",
+    "zh:e338af6474db7feb142287f93460d43d5c892a150c91f26354dff1b0294438a4",
+    "zh:ebdc4cc6c655ba9c1c3b3fbf3d7464d84a31e74fa5b484676fbdfd8870f29128",
   ]
 }

--- a/terraform/configurations/dns/backend.tf
+++ b/terraform/configurations/dns/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   cloud {
     organization = "justinrubek"
+    hostname = "app.terraform.io"
 
     workspaces {
       name = "dns"
@@ -13,9 +14,10 @@ terraform {
       version = "0.1.2"
     }
     vault = {
+      source = "hashicorp/vault"
       version = "3.11.0"
     }
   }
 
-  required_version = ">= 1.0"
+  required_version = "1.6.0"
 }

--- a/terraform/configurations/github/.terraform.lock.hcl
+++ b/terraform/configurations/github/.terraform.lock.hcl
@@ -1,42 +1,63 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/github" {
-  version = "5.18.0"
+provider "registry.opentofu.org/hashicorp/github" {
+  version = "5.42.0"
   hashes = [
-    "h1:2ZqZ5TM66Un+UgDbZkKhhbxQaR2VXpsW0Ul5DzKjJEk=",
-    "zh:2030909af32ef42493e1bcc09ed27b77fc7e93b902ff3f78f92877176cb75ad2",
-    "zh:390f253ae743dfb818334ff669ed45e10f90b9758a5e8c71a3699cac54a781f8",
-    "zh:3d7c694648dad729ae8c48173c300c10fedbf55dc29525b94fab78dcfebe727f",
-    "zh:46c0ea383516b85ecc40e1e1b9ab974d03c94305bc3fd570b493a00736ff3929",
-    "zh:4df27856b9553d1c240b24e759da79ac305611fed9368a527fb6e5d2ba7cdb32",
-    "zh:757ac517a58098324b7ecff48bee55bc7648558ae45198080ee00215414ab70a",
-    "zh:7cd9c92e44252b5b7794eb98fad41fc51f1ce5119899cc450fd60c36964c4aca",
-    "zh:a69ec9db536f6ffc2e45324cd4c8133a18f3d0f8e266a531d2ef07a0da5de9c9",
-    "zh:aad0d3d19c10c6373c00bc29a93932601129ed0927d76068f90073f7df851735",
-    "zh:b00c4933fa091420af7f149d4c6bb2348a87dadc16d1474a1dfd4e435fbdec49",
-    "zh:d6dd1e6e3c42ef76006c24db662d90ca6e623e543fa924db2c49185ec98a9f57",
-    "zh:e0e60989b84f52db929eb12952a5971dec78efbad9f6d74fd7dfd95127833c0d",
-    "zh:e925a155a07a982c731e7deec5e0acb419fd6c5ab2d1666af5395386a1e9c0fe",
-    "zh:eb9b833594a585f22142dfc624416104c66eaafef8ddd6298d23a528896eeb6e",
+    "h1:vHTdYL6eXJfUzz4bs0ICyg2f8ct/K2EnGAjwLrAmL3U=",
+    "zh:0f97039c6b70295c4a82347bc8a0bcea700b3fb3df0e0be53585da025584bb7c",
+    "zh:12e78898580cc2a72b5f2a77e191b158f88e974b0500489b691f34842288745c",
+    "zh:23660933e4f00293c0d4d6cd6b4d72e382c0df46b70cecf22b5c4c090d3b61e3",
+    "zh:74119174b46d8d197dd209a246bf8b5db113c66467e02c831e68a8ceea312d3e",
+    "zh:829c4c0c202fc646eb0e1759eb9c8f0757df5295be2d3344b8fd6ca8ce9ef33b",
+    "zh:92043e667f520aee4e08a10a183ad5abe5487f3e9c8ad5a55ea1358b14b17b1a",
+    "zh:998909806b4ff42cf480fcd359ec1f12b868846f89284b991987f55de24876b7",
+    "zh:9f758447db3bf386516562abd6da1e54d22ddc207bda25961d2b5b049f32da0f",
+    "zh:a6259215612d4d6a281c671b2d5aa3a0a0b0a3ae92ed60b633998bb692e922d3",
+    "zh:ad7d78056beb44191911db9443bf5eec41a3d60e7b01def2a9e608d1c4288d27",
+    "zh:b697e7b0abef3000e1db482c897b82cd455621b488bb6c4cd3d270763d7b08ac",
+    "zh:db8e849eded8aebff780f89ab7e1339053d2f15c1c8f94103d70266a090527ad",
+    "zh:e5bdbb85fb148dd75877a7b94b595d4e8680e495c241db02c4b12b91e9d08953",
+    "zh:ee812c5fd77d3817fb688f720e5eb42d7ff04db67a125de48b05458c9f657483",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/vault" {
-  version = "3.14.0"
+provider "registry.opentofu.org/hashicorp/vault" {
+  version     = "3.23.0"
+  constraints = "3.23.0"
   hashes = [
-    "h1:/0pqMLODukJUiVpBdxXbb8vwp0HCtbTXWFq0BaNkcZM=",
-    "zh:07e797c3b14cc45f1a3fa3adb6269f28f182630b9af9403a2a447919d4e9992a",
-    "zh:0d88c6c50f7975f60c84d446bf95b26652c9457e62f2d5b24221b769d6daf809",
-    "zh:1670c513f85788308d317e45038234ac367f52f7bd0ea8f527f0a6291dd23659",
-    "zh:1b5a07fd053a0d7d1da80cb3e929b44c000c614d3738bb7ff82b4d56ed854017",
-    "zh:34a43de7f3d3749cbc50b81b84fe38961c3dfbda819708a814c2206045ecf69b",
-    "zh:416f710365d060c8239522363257e162a267c01463ac95ad2c2dd0acf05b6d35",
-    "zh:73956090e0e9b69adbcfe1bcaad20ec45779f2e7f3f2fb3a5f865402a2cd2485",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:e2df6077e925a8438cfd2deb3bce5f1029a2e3edd2a635b12636d426390600dd",
-    "zh:e3e2797ae1cfc6aff66329ee81baaf780e1f5f295ad887ac7ff4c1e2754a8c8c",
-    "zh:f34ec435d16244ecf0f909872850070428aeadd352b6a21ab1f787d81f8bae9f",
-    "zh:f3a930e64b2c10d2ece5acc856d3438cdd375ccfc5ac10fc4a8fe163f74af93a",
+    "h1:roZ6JT8DYUD74HBhD3qC5zcAVXWcrkMaUNiEbma0Ed0=",
+    "zh:23d5a36a4fb9434ad7411099d1e807774b900364f2944c236e86c84dc7d61341",
+    "zh:71c28006907f94f414c8e07ee43de2d56c9f6d4a04ec68e8ae9ef5f273b77bce",
+    "zh:9ab1d71ff21c7639584f01169034e3978ffa1e0bbe5a0dfaa5d7b6f5fc1ed4e2",
+    "zh:ae416d6d45f1ba1627d58cafbdf7cc943dfaf6d5cef857e6997f6f776abaa92e",
+    "zh:c0a6e3053b6fd0cadc8f75be85f9f925e661950b0444a0e50ac44e8e0e083f85",
+    "zh:cc0d448b7db639734a9781ae8ee885784f919e1ab0286dafb96a5c6fcfe666ba",
+    "zh:cc74da7cae70b8afdca9fc00b5c86f3c0815ab96d2265104e27da414a1f03a50",
+    "zh:d9a0e66f89bda5a04fd25c33995eba0788cc2914bb7b7059acbad9123c3b8aea",
+    "zh:efafcd9931ab8bab9b4aeea60a433d44437daf4703fcf81f7d9f7a7a45d35bef",
+    "zh:f92d259f31229ec83a2a8bb4ade6d3a8b1079240e1f059e471c894de70f24072",
+  ]
+}
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "5.42.0"
+  constraints = "5.42.0"
+  hashes = [
+    "h1:vHTdYL6eXJfUzz4bs0ICyg2f8ct/K2EnGAjwLrAmL3U=",
+    "zh:0f97039c6b70295c4a82347bc8a0bcea700b3fb3df0e0be53585da025584bb7c",
+    "zh:12e78898580cc2a72b5f2a77e191b158f88e974b0500489b691f34842288745c",
+    "zh:23660933e4f00293c0d4d6cd6b4d72e382c0df46b70cecf22b5c4c090d3b61e3",
+    "zh:74119174b46d8d197dd209a246bf8b5db113c66467e02c831e68a8ceea312d3e",
+    "zh:829c4c0c202fc646eb0e1759eb9c8f0757df5295be2d3344b8fd6ca8ce9ef33b",
+    "zh:92043e667f520aee4e08a10a183ad5abe5487f3e9c8ad5a55ea1358b14b17b1a",
+    "zh:998909806b4ff42cf480fcd359ec1f12b868846f89284b991987f55de24876b7",
+    "zh:9f758447db3bf386516562abd6da1e54d22ddc207bda25961d2b5b049f32da0f",
+    "zh:a6259215612d4d6a281c671b2d5aa3a0a0b0a3ae92ed60b633998bb692e922d3",
+    "zh:ad7d78056beb44191911db9443bf5eec41a3d60e7b01def2a9e608d1c4288d27",
+    "zh:b697e7b0abef3000e1db482c897b82cd455621b488bb6c4cd3d270763d7b08ac",
+    "zh:db8e849eded8aebff780f89ab7e1339053d2f15c1c8f94103d70266a090527ad",
+    "zh:e5bdbb85fb148dd75877a7b94b595d4e8680e495c241db02c4b12b91e9d08953",
+    "zh:ee812c5fd77d3817fb688f720e5eb42d7ff04db67a125de48b05458c9f657483",
   ]
 }

--- a/terraform/configurations/github/backend.tf
+++ b/terraform/configurations/github/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   cloud {
     organization = "justinrubek"
+    hostname = "app.terraform.io"
 
     workspaces {
       name = "github"
@@ -9,9 +10,16 @@ terraform {
 
   required_providers {
     github = {
-      version = "5.18.0"
+      source = "integrations/github"
+      version = "5.42.0"
+     
+    }
+    vault = {
+      source = "hashicorp/vault"
+      version = "3.23.0"
+     
     }
   }
 
-  required_version = ">= 1.0"
+  required_version = "1.6.0"
 }

--- a/terraform/configurations/hetzner/.terraform.lock.hcl
+++ b/terraform/configurations/hetzner/.terraform.lock.hcl
@@ -1,32 +1,28 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/random" {
+provider "registry.opentofu.org/hashicorp/random" {
   version     = "3.4.3"
   constraints = "3.4.3"
   hashes = [
-    "h1:8jXFvZIJ2eGk7zYNq8XZgugJMpMPW3m9U6eGRC/S5yI=",
-    "h1:xZGZf18JjMS06pFa4NErzANI98qi59SEcBsOcS2P2yQ=",
-    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
-    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
-    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
-    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
-    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
-    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
-    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
-    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
-    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
-    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+    "h1:57xIMCTAE78wv9naPFb3atFFEFn3rW1hOFYTrXMk/C0=",
+    "zh:40f2ab718f177b0f8ec29da906104583047531de32cd7dc7f005a606a099d474",
+    "zh:6a6684084bd1624b93a262663c5849f9efb597c99d6b03eeb6dbd685760561fb",
+    "zh:8dc1973537166b468c08526ef38fa353f389df4ae9639cf8591dbc6e6048336b",
+    "zh:aa260ea7793988e7f45ea3916ed6e177f8827e9dd3959fe799cbeda2329e7d23",
+    "zh:b59bbf92b7be796c1921acf22b40fbb5e699bd3e9bdc06fa27a7e273509e1028",
+    "zh:c4603614ca8c73f3c9b00cb4e89d3b859a62864cf09faba2ae376689a354f326",
+    "zh:d82ba8432161763525dc7e8f32ac2377ea444829f805511cb90369b147c62b0c",
+    "zh:ee058d8839b35e1dbcfea224652e6e921e015d3454e0c06e8afce3516bb50910",
+    "zh:efffc2adfbfdbfde4f7fc9f423338c5969054de064b7afcd391fa2c419da2bc2",
+    "zh:f0530bdae9985a3be630679d6c29396721616148a08594bb0a55551a69c53c13",
   ]
 }
 
-provider "registry.terraform.io/hetznercloud/hcloud" {
+provider "registry.opentofu.org/hetznercloud/hcloud" {
   version     = "1.36.1"
   constraints = "1.36.1"
   hashes = [
-    "h1:GjELvsVRe0nbSvA0FRf/5Jj/fifd84vAmqZ+9T2pX8s=",
     "h1:xZSvxx6aUo0oZp2uqNxi/+wqnCNEBBuu8y7GeXIO9qA=",
     "zh:16558b25c7f92f187278e94e951b0ab687882b06acff5b1387f3293f27939f8c",
     "zh:28fc79ac2189ff0f5e6c9535ada8f57552b6e21c978b59dc78e086c27b9e4b23",

--- a/terraform/configurations/hetzner/backend.tf
+++ b/terraform/configurations/hetzner/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   cloud {
     organization = "justinrubek"
+    hostname = "app.terraform.io"
 
     workspaces {
       name = "hetzner"
@@ -18,5 +19,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.0"
+  required_version = "1.6.0"
 }

--- a/terraform/configurations/minio/.terraform.lock.hcl
+++ b/terraform/configurations/minio/.terraform.lock.hcl
@@ -1,7 +1,7 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/aminueza/minio" {
+provider "registry.opentofu.org/aminueza/minio" {
   version     = "1.17.2"
   constraints = "1.17.2"
   hashes = [

--- a/terraform/configurations/minio/backend.tf
+++ b/terraform/configurations/minio/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   cloud {
     organization = "justinrubek"
+    hostname = "app.terraform.io"
 
     workspaces {
       name = "minio"
@@ -14,5 +15,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.0"
+  required_version = "1.6.0"
 }

--- a/terraform/configurations/vault/.terraform.lock.hcl
+++ b/terraform/configurations/vault/.terraform.lock.hcl
@@ -1,12 +1,11 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/carlpett/sops" {
+provider "registry.opentofu.org/carlpett/sops" {
   version     = "0.7.1"
   constraints = "0.7.1"
   hashes = [
     "h1:/LNLI9qKgRjlHhyl1M/6BA+HVUMQ9RQApZgyfV4RAJ4=",
-    "h1:uM3Y0nypi8hlZixoXXXWIlBf4Fw012PRECbtFKy4yyQ=",
     "zh:203d5ab6af38efb9fc84fdbb303218aa5012dc8d28e700642be41bbc4b1c2fa1",
     "zh:5684a2dc65da50824fb4275c10ac452e6512dd0d60a9abd5f505e67e7b9d759a",
     "zh:b4311d7cae0b29f2dcf5a18a8297ed0787f59b140102547da9f8b61af27e15b6",
@@ -17,44 +16,38 @@ provider "registry.terraform.io/carlpett/sops" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/consul" {
+provider "registry.opentofu.org/hashicorp/consul" {
   version     = "2.16.2"
   constraints = "2.16.2"
   hashes = [
-    "h1:epldE7sZPBTQHnWEA4WlNJIOVT1UEX+/02SMg5nniaE=",
-    "zh:0a2e11ca2ba650954951a087a1daec95eee2f3000456b295409a9880c4a10b1a",
-    "zh:34f6bda06a0d1c213fa8d87d4313687681e67bc8c40c4cbaa7dbe59ce24a4f7e",
-    "zh:5b85cf93db11ee890f720c317a38158927071feb634855786a0c0cd65825a43c",
-    "zh:75ef915f3d087e6045751a66fbb7066a852a0944ec8c97200d1134dd84df7ffc",
-    "zh:8a4a95697bd91ad51a581c12fe50ac61a114afba27895d027f77ac4154a7ea15",
-    "zh:973d538c8d72793861a1ac9718249a9493f417a2b5096846367560054fd843b9",
-    "zh:9feb2bdc06fdc2d8370cc9aad9a0c69e7e5ae38aac43f315c3f57507c57be030",
-    "zh:c5709672d0afecbbe298bf519741ebcb9d04f02a73b5ee0c186dfa241aa5a524",
-    "zh:c65c60570de6da7190e1e7762577655a463caeb59bc5d38e33034821ed0cbcb9",
-    "zh:c958d6282650fc472aade61d5df4300936033f43cfb898293ef86aceccdfdf1d",
-    "zh:cdd3632c81e1d11d3becd193aaa061688840f39147950c45c4301d042743ae6a",
-    "zh:f3d3efac504c9484a025beb919d22b290aa6dbff256f6e86c1f8ce7817e077e5",
+    "h1:OYRTbBbEVN7unGAtivV5dhug7UMv5ejaxWgqL2eZ/Cc=",
+    "zh:02af1adc894745b93fcf7e30f0437dfcdae596477a770329b29f2eb7c41e4738",
+    "zh:2ec8b1a01414e955416b8a796c06fcd06622ddd3fce7b93f0dc34ba117a6007e",
+    "zh:460d03e38b6f5cc3181f8349ee845afe858d8e064f7bb6eb90770bbb0a3d1380",
+    "zh:46e571cf15078a3bfc4f90efbe3accbe211a01fbb138175be68aeab03a514aab",
+    "zh:501ad160c0c4d9a4a85409a0332fdd2c3f291d9a3dcb5c2f7c3743ce8f39fbbb",
+    "zh:75d094b61271bb55508c56b2c8ea64c04f1d5bd631d9519214369925b7eeb68a",
+    "zh:92fcfda6719c57e4f50c50e9e850e9885f63afd18dc66e259dcbed2477e99293",
+    "zh:9d0cbbda7e6c724a1d44e5de0a6c9cdb9a07124318397831b7f95142463fee33",
+    "zh:aa5abc7e3242a4905c1dfbf5bc6f00568cdc0ae2dc10f37d726f61f2b41e5b7e",
+    "zh:ebb5d962079314328d4979643523bc87bec329b1c1c4b8b9d5f2b3f133b39bc7",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/vault" {
+provider "registry.opentofu.org/hashicorp/vault" {
   version     = "3.11.0"
   constraints = "3.11.0"
   hashes = [
-    "h1:AUVEra6fAOiAUWa0FOU+ehx4K2htbsfgLDrMh1H6mQs=",
-    "h1:XRfCDT8lnPhSmcychzYCFH2AMrULfrN+qLFf+9rjG+0=",
-    "h1:rAnPcQmzz9QZcVf/8hV5SsDbcFoDJuHZphzfCaeBxnI=",
-    "zh:18cb684852f1b40b2a329ba07ece3363430d69bffdcafea48ed29f954481e39e",
-    "zh:1b96968a8de6849a237cc945cbe247ccd6ec98b4023548b1c0af5d6c6affe4ef",
-    "zh:3e0a0741ba12aa0cf1a2b8b80928450bb329343f4b41f35b0eddbeb52aa6284b",
-    "zh:4a8f0ee5ac4e8a0705d9f38b3d549223fe1142486d71f0b6f24f64ae0d7dd5ca",
-    "zh:4cc6705dcd111e6ad47ab4cfd2d8a99b2b241967abd50add6ac8c27025f4128b",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8e106e840a963b9ae32dc24b50fa1ceecb09753e6db10ab134009d59d170686b",
-    "zh:8f9c4ccf4da8555b11375d2a09a022d7a8f5ecf701f0bb89a4f07ad0b720bb98",
-    "zh:a6fda115017b42f71f4b7917ae4860354920f0653cb8906ce627129dbabb252b",
-    "zh:c01666362b293b6af8cd556b2c5ffe9014ae8640ec3621c1cfa772fa1a6b335d",
-    "zh:e9be58b1211da0219a5bf6bfd81b8bf474256519426df10672e6dfce3086af60",
-    "zh:fd2272083e90b38c28cd18b1b9d3ae14b6a0ebf08985468d010d2bee8df816e0",
+    "h1:82HeeI++FQCwIxWkt344S2K9Epcdj74XMPQehekNwXI=",
+    "zh:13c84ce1ffeaa98f6ec00d39b570b3b02b46bb7f550d9d77adfbbc6a5f236bb3",
+    "zh:54e93ff32a599875ad9441c5f1ca0c1f11329474a483895a033f30771c692e47",
+    "zh:54fab02b23c021c0a7171e33ba1ac6be0ea3986ce4e97de0f21413506109a421",
+    "zh:8a016e456014b88e217f93edd8a3ec0663d3669781d7709304e94536f7820fb3",
+    "zh:9ccfbb19b10ad654cd45c2f54a8ea6abd79f570f6f474b1522c30473a52055fe",
+    "zh:a9492d604633b3c92033cfc2eebe9f51300f9dc7ea38459d6394514242fc5809",
+    "zh:b878f04e59b0ab061015a64d76a96bbc7a26b0d4b1065ef81df913a6fffcfd77",
+    "zh:c456639e7024d3120d9cb0b2fcb0c875443e31212ab8f05e52c4d43591496631",
+    "zh:e338af6474db7feb142287f93460d43d5c892a150c91f26354dff1b0294438a4",
+    "zh:ebdc4cc6c655ba9c1c3b3fbf3d7464d84a31e74fa5b484676fbdfd8870f29128",
   ]
 }

--- a/terraform/configurations/vault/backend.tf
+++ b/terraform/configurations/vault/backend.tf
@@ -1,6 +1,7 @@
 terraform {
   cloud {
     organization = "justinrubek"
+    hostname = "app.terraform.io"
 
     workspaces {
       name = "vault"
@@ -9,9 +10,11 @@ terraform {
 
   required_providers {
     vault = {
+      source = "hashicorp/vault"
       version = "3.11.0"
     }
     consul = {
+      source = "hashicorp/consul"
       version = "2.16.2"
     }
     sops = {
@@ -20,5 +23,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.0"
+  required_version = "1.6.0"
 }


### PR DESCRIPTION
Opentofu is used in place of terraform. Many options have been specified explicitly for compatibility. This repository still depends on terraform cloud so the url has been set to reflect this. All configurations have been tested against opentofu and the terraform lockfiles reflect this change.

The thoenix cli has been updated so it now defaults to using tofu.

Many of the names used in this repository remain to be `terraform` because this change makes no attempts to change them. The only difference currently is that the package is switched out to opentofu and the configurations contained within work properly with it.